### PR TITLE
Support mock deep merge

### DIFF
--- a/combineMocks.js
+++ b/combineMocks.js
@@ -27,6 +27,9 @@ const chainMockExecution = mocks => {
       const wrapperFunction = function() {
         return funcArray.reduce((obj, func) => {
           const funcResult = func.apply(null, arguments);
+          if (funcResult === null) {
+            return null;
+          }
           return Object.assign(obj, funcResult);
         }, {});
       };

--- a/combineMocks.js
+++ b/combineMocks.js
@@ -1,17 +1,60 @@
 const unwrap = fn => (fn ? fn() : {});
+
+const smartMergeQueryMocks = (left, right) => {
+  const leftAndRight = {...left};
+
+  Object.keys(right).forEach(key => {
+    if (key in left) {
+      if (Array.isArray(left[key])) {
+        leftAndRight[key].push(right[key]);
+      } else {
+        leftAndRight[key] = [left[key], right[key]];
+      }
+    } else {
+      leftAndRight[key] = right[key];
+    }
+  });
+
+  return leftAndRight;
+};
+
+const chainMockExecution = mocks => {
+  const chainedMocks = {};
+
+  Object.keys(mocks).forEach(k => {
+    if (Array.isArray(mocks[k])) {
+      const funcArray = mocks[k];
+      const wrapperFunction = function() {
+        return funcArray.reduce((obj, func) => {
+          const funcResult = func.apply(null, arguments);
+          return Object.assign(obj, funcResult);
+        }, {});
+      };
+      chainedMocks[k] = wrapperFunction;
+    } else {
+      chainedMocks[k] = mocks[k];
+    }
+  });
+
+  return chainedMocks;
+};
+
 const combineMocks = (schema, ...mocks) => {
   const MutationTypeName = schema.getMutationType().name;
-  return mocks.reduce(
-    (left, right) => ({
-      ...left,
-      ...right,
+
+  const mergedMocks = mocks.reduce((left, right) => {
+    const {[MutationTypeName]: leftMutationType, ...leftQueryMock} = left;
+    const {[MutationTypeName]: rightMutationType, ...rightQueryMock} = right;
+
+    return {
+      ...smartMergeQueryMocks(leftQueryMock, rightQueryMock),
       [MutationTypeName]: () => ({
-        ...unwrap(left[MutationTypeName]),
-        ...unwrap(right[MutationTypeName]),
+        ...unwrap(leftMutationType),
+        ...unwrap(rightMutationType),
       }),
-    }),
-    {}
-  );
+    };
+  }, {});
+  return chainMockExecution(mergedMocks);
 };
 
 module.exports = combineMocks;

--- a/combineMocks.js
+++ b/combineMocks.js
@@ -1,28 +1,18 @@
 const unwrap = fn => (fn ? fn() : {});
 
-const chainMerge = (left, right) => {
-  const leftAndRight = {...left};
+const chainMerge = (left, right) =>
+  Object.entries(right).reduce(
+    (merged, [key, rightFn]) => {
+      const mergedFn = key in merged ? mergeFns(merged[key], rightFn) : rightFn;
+      return Object.assign(merged, {[key]: mergedFn});
+    },
+    {...left}
+  );
 
-  Object.keys(right).forEach(key => {
-    if (key in left) {
-      leftAndRight[key] = function() {
-        const rightObj = right[key].apply(null, arguments);
-
-        if (rightObj === null) {
-          return null;
-        }
-
-        return {
-          ...left[key].apply(null, arguments),
-          ...rightObj,
-        };
-      };
-    } else {
-      leftAndRight[key] = right[key];
-    }
-  });
-
-  return leftAndRight;
+const mergeFns = (leftFn, rightFn) => (...args) => {
+  const rightValue = rightFn(...args);
+  if (rightValue === null) return rightValue;
+  return Object.assign(leftFn(...args), rightValue);
 };
 
 const combineMocks = (schema, ...mocks) => {

--- a/index.test.js
+++ b/index.test.js
@@ -234,7 +234,7 @@ describe('Mock', () => {
       expect(returnIntArgument).toEqual(6);
     });
 
-    it("does not stomp on previously returned mock values", async () => {
+    it('does not stomp on previously returned mock values', async () => {
       const schema = buildSchemaFromTypeDefinitions(schemaString);
       const left = {
         Foo: () => ({

--- a/index.test.js
+++ b/index.test.js
@@ -9,6 +9,8 @@ const schemaString = `
   type Foo {
     id: ID!
     stringValue: String
+    boolValue: Boolean
+    intValue: Int
     bar: Bar
   }
   type Bar {
@@ -264,6 +266,44 @@ describe('Mock', () => {
       const {data: {fooInstance: fooInstance2}} = await graphql(schema, testQuery);
 
       expect(fooInstance).toEqual(fooInstance2);
+    });
+
+    it('deep merges properties of partial mocks', async () => {
+      const schema = buildSchemaFromTypeDefinitions(schemaString);
+      const fooMocksBase = {
+        Foo: () => ({
+          id: Math.random(),
+          stringValue: 'foo',
+          boolValue: true,
+          intValue: 54,
+        }),
+      };
+      const fooMocksOverrideOne = {
+        Foo: () => ({
+          stringValue: 'bar',
+        }),
+      };
+      const fooMocksOverrideTwo = {
+        Foo: () => ({
+          intValue: 56,
+        }),
+      };
+      addMockFunctionsToSchema({
+        schema,
+        mocks: [fooMocksBase, fooMocksOverrideOne, fooMocksOverrideTwo],
+      });
+      const testQuery = `{
+        fooInstance {
+          id
+          stringValue
+          boolValue
+          intValue
+        }
+      }`;
+      const {data: {fooInstance}} = await graphql(schema, testQuery);
+      expect(fooInstance.stringValue).toEqual('bar');
+      expect(fooInstance.boolValue).toEqual(true);
+      expect(fooInstance.intValue).toEqual(56);
     });
   });
 


### PR DESCRIPTION
Our current implementation of query mocking only allows the latest
version of a particular mock to be in effect. This means that each time
you mock an object, you need to provide all properties for that object
in its entirety. This creates a lot of overhead when we only want to
mock a specific property on a mock for testing purposes.

This change adds support for allowing subsequent mocks to override
properties on any mocking functions that existed prior to that mock.

For example, if you have the following base mock object with defaults
defined as:
```javascript
Person: {
  id: 1,
  firstName: "John",
  lastName: "Doe",
  age: 35
}
```
And you are running a test where you are testing logic that consumes
age, you may want to mock person without regard for what their name is:
```javascript
Person: {
  age: 21
}
```

In today's world, you would get back the following when consuming the
Person object:
```javascript
Person: {
  age: 21
}
```
With this change in place, you would instead get:
```javascript
Person: {
  id: 1,
  firstName: "John",
  lastName: "Doe",
  age: 21
}
```