### PR TITLE
add naive support for tracking mutations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 npm-debug.log*
 
 .idea/*
+.vscode

--- a/index.js
+++ b/index.js
@@ -20,14 +20,8 @@ exports.addMockFunctionsToSchema = ({schema, mocks: mocksIn = {}, preserveResolv
 
   const {clear, find, reset, track} = store(schema);
 
-  const MutationTypeName = schema.getMutationType().name;
-
-  forEachField(schema, (field, typeName) => {
-    const wrappers = [addToContext({clear, find, reset})];
-
-    if (typeName !== MutationTypeName) {
-      wrappers.unshift(track);
-    }
+  forEachField(schema, (field) => {
+    const wrappers = [track, addToContext({clear, find, reset})];
 
     field.resolve = compose(...wrappers)(field.resolve);
   });


### PR DESCRIPTION
FYI, this PR is intended to elicit feedback, not necessarily to be merged.

This is a naive attempt to track mutation results, such that a subsequent query mock can use `context.find` to get a mutation's result and transform it into an appropriate return value, as described in #149.

I'm not a GraphQL expert -- this is just the result of me fumbling around with a debugger, trying to find some way to support my use case.  If anyone has any constructive feedback, please don't hesitate to comment.